### PR TITLE
Fix Docker container crash: pin transformers dependency and replace deprecated encode_plus

### DIFF
--- a/requirements-security.txt
+++ b/requirements-security.txt
@@ -13,19 +13,20 @@ starlette>=0.46.2
 # CVE-2025-50181/50182: urllib3 redirect control
 # CVE-2024-11392/93/94: transformers security issues
 h11>=0.16.0
-transformers>=4.53.0
+transformers==4.53.0
 requests>=2.32.4
 urllib3>=2.5.0
 setuptools>=78.1.1
 aiohttp>=3.12.14
 
-# ML/AI dependencies - allow compatible versions
-torch>=2.7.1
+# ML/AI dependencies - pinned to tested compatible versions
+# Upper bounds prevent untested major upgrades from breaking the container
+torch>=2.7.1,<2.8
 tokenizers>=0.21,<0.22
-huggingface-hub>=0.35.3
-safetensors>=0.4.5
-numpy>=2.4.2
-peft>=0.17.1
+huggingface-hub>=0.35.3,<0.36
+safetensors>=0.4.5,<0.5
+numpy>=2.4.2,<3.0
+peft>=0.17.1,<0.18
 
 # Other dependencies - allow latest compatible
 pydantic>=2.9.1

--- a/src/api_interface/services/prediction_service.py
+++ b/src/api_interface/services/prediction_service.py
@@ -53,7 +53,7 @@ class PredictionService:
         """
         max_length = max_len or settings.max_text_length
 
-        return tokenizer.encode_plus(
+        return tokenizer(
             text,
             add_special_tokens=True,
             max_length=max_length,

--- a/src/mBERT/tests/stressTest_1000_mlx.py
+++ b/src/mBERT/tests/stressTest_1000_mlx.py
@@ -23,7 +23,7 @@ def load_model(model_path, device):
     return model
 
 def preprocess_text(text, tokenizer, max_len=128):
-    encoding = tokenizer.encode_plus(
+    encoding = tokenizer(
         text,
         add_special_tokens=True,
         max_length=max_len,

--- a/src/mBERT/tests/stressTest_500.py
+++ b/src/mBERT/tests/stressTest_500.py
@@ -8,7 +8,7 @@ def load_model(model_path):
     return model
 
 def preprocess_text(text, tokenizer, max_len=128):
-    encoding = tokenizer.encode_plus(
+    encoding = tokenizer(
         text,
         add_special_tokens=True,
         max_length=max_len,

--- a/src/mBERT/tests/test_sms.py
+++ b/src/mBERT/tests/test_sms.py
@@ -8,7 +8,7 @@ def load_model(model_path):
     return model
 
 def preprocess_text(text, tokenizer, max_len=128):
-    encoding = tokenizer.encode_plus(
+    encoding = tokenizer(
         text,
         add_special_tokens=True,
         max_length=max_len,

--- a/src/mBERT/training/model-training/compare_models.py
+++ b/src/mBERT/training/model-training/compare_models.py
@@ -53,7 +53,7 @@ class ModelComparator:
         predictions = []
         with torch.no_grad():
             for text in texts:
-                inputs = tokenizer.encode_plus(
+                inputs = tokenizer(
                     text,
                     add_special_tokens=True,
                     max_length=self.max_len,

--- a/src/mBERT/training/model-training/train_enhanced_multilingual.py
+++ b/src/mBERT/training/model-training/train_enhanced_multilingual.py
@@ -75,7 +75,7 @@ class MultilingualSMSDataset(Dataset):
         text = self._preprocess_text(text)
 
         # Tokenize
-        encoding = self.tokenizer.encode_plus(
+        encoding = self.tokenizer(
             text,
             add_special_tokens=True,
             max_length=self.max_len,

--- a/src/mBERT/training/model-training/train_incremental.py
+++ b/src/mBERT/training/model-training/train_incremental.py
@@ -146,7 +146,7 @@ class IncrementalTrainer:
                 text = str(self.texts[item])
                 label = self.labels[item]
 
-                encoding = self.tokenizer.encode_plus(
+                encoding = self.tokenizer(
                     text,
                     add_special_tokens=True,
                     max_length=self.max_len,

--- a/src/mBERT/training/model-training/train_ots.py
+++ b/src/mBERT/training/model-training/train_ots.py
@@ -25,7 +25,7 @@ class TextDataset(Dataset):
     def __getitem__(self, item):
         text = str(self.texts[item])
         label = self.labels[item]
-        encoding = self.tokenizer.encode_plus(
+        encoding = self.tokenizer(
             text,
             add_special_tokens=True,
             max_length=self.max_len,

--- a/src/mBERT/training/model-training/train_ots_improved.py
+++ b/src/mBERT/training/model-training/train_ots_improved.py
@@ -62,7 +62,7 @@ class EnhancedTextDataset(Dataset):
             text = str(self.texts[item])
             label = self.labels[item]
             
-            encoding = self.tokenizer.encode_plus(
+            encoding = self.tokenizer(
                 text,
                 add_special_tokens=True,
                 max_length=self.max_len,


### PR DESCRIPTION
The Docker builds using requirements-security.txt had transformers>=4.53.0 (unpinned
upper bound), which pulled a newer incompatible version where BertTokenizer.encode_plus
was removed. This caused all classification requests to fail with:
  "BertTokenizer has no attribute encode_plus"

Changes:
- Pin transformers==4.53.0 in requirements-security.txt (matches requirements.txt)
- Add upper bounds to torch, huggingface-hub, safetensors, numpy, peft to prevent
  similar untested major version upgrades from breaking Docker builds
- Replace all tokenizer.encode_plus() calls with tokenizer() across the codebase
  (the __call__ method is the modern, forward-compatible API that accepts identical
  parameters)

Affected files: prediction_service.py, test_sms.py, stressTest_500.py,
stressTest_1000_mlx.py, train_ots.py, train_ots_improved.py, compare_models.py,
train_incremental.py, train_enhanced_multilingual.py
