### PR TITLE
deps(security): bump vulnerable packages to patched versions (safe patches + minors)

### DIFF
--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -9,11 +9,11 @@ pydantic-settings>=2.0.0
 
 # ML dependencies
 # torch 2.8+ for CVE-2025-3730; transformers stays on 4.53.x until 5.x stable
-torch>=2.8.0,<2.9
+torch>=2.9.1,<2.10
 transformers>=4.53.0,<5.0
 numpy>=2.4.2
 
 # Additional dependencies
 requests>=2.33.0
-urllib3>=2.5.0
+urllib3>=2.7.0
 Jinja2>=3.0.0

--- a/requirements-security.txt
+++ b/requirements-security.txt
@@ -16,7 +16,7 @@ h11>=0.16.0
 # transformers 5.x is still an RC with API breaks — stay on 4.53.x until stable release.
 transformers>=4.53.0,<5.0
 requests>=2.33.0
-urllib3>=2.5.0
+urllib3>=2.7.0
 setuptools>=78.1.1
 aiohttp>=3.13.4
 cryptography>=46.0.7
@@ -24,7 +24,7 @@ cryptography>=46.0.7
 # ML/AI dependencies - pinned to tested compatible versions
 # Upper bounds prevent untested major upgrades from breaking the container
 # torch bumped to 2.8+ for CVE-2025-3730 (DoS in torch.mkldnn_max_pool2d)
-torch>=2.8.0,<2.9
+torch>=2.9.1,<2.10
 tokenizers>=0.21,<0.22
 huggingface-hub>=0.35.3,<0.36
 safetensors>=0.4.5,<0.5
@@ -40,7 +40,7 @@ certifi>=2024.8.30
 charset-normalizer>=3.3.2
 filelock>=3.16.0
 fsspec>=2024.9.0
-idna>=3.8
+idna>=3.15
 Jinja2>=3.1.6
 MarkupSafe>=2.1.5
 packaging>=24.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ fsspec==2024.9.0
 h11==0.16.0
 httpx>=0.27.0
 huggingface-hub
-idna==3.8
+idna==3.15
 Jinja2==3.1.6
 MarkupSafe==2.1.5
 mpmath==1.3.0
@@ -30,11 +30,11 @@ sniffio==1.3.1
 starlette==0.49.1
 sympy>=1.13.3
 tokenizers>=0.21,<0.22
-torch>=2.8.0,<2.9
+torch>=2.9.1,<2.10
 tqdm==4.66.5
 transformers>=4.53.0,<5.0
 typing_extensions==4.12.2
-urllib3>=2.5.0
+urllib3>=2.7.0
 uvicorn==0.30.6
 
 # Training dependencies

--- a/src/mBERT/training/model-training/requirements.txt
+++ b/src/mBERT/training/model-training/requirements.txt
@@ -1,5 +1,5 @@
 accelerate==0.25.0
-aiohttp==3.13.3
+aiohttp==3.14.0
 aiosignal==1.3.1
 altgraph==0.17.4
 anyio==3.7.1
@@ -21,14 +21,14 @@ chardet==5.2.0
 charset-normalizer==2.1.1
 click==8.1.3
 contourpy==1.0.7
-cryptography==46.0.5
+cryptography==46.0.7
 cycler==0.11.0
 decorator==5.1.1
 dill==0.3.2
 dnslib==0.9.23
 dnspython==2.6.1
 docstring-to-markdown==0.12
-ecdsa==0.19.0
+ecdsa==0.19.2
 emoji==2.4.0
 et-xmlfile==1.1.0
 exceptiongroup==1.1.3
@@ -47,7 +47,7 @@ graphviz==0.8.4
 h11==0.16.0
 htmlmin==0.1.12
 huggingface-hub==0.20.1
-idna==3.7
+idna==3.15
 ImageHash==4.3.1
 importlib-metadata==6.0.0
 ipython==8.13.1
@@ -94,7 +94,7 @@ pbr==5.11.1
 pexpect==4.8.0
 phik==0.12.3
 pickleshare==0.7.5
-Pillow==12.1.1
+Pillow==12.2.0
 platformdirs==3.2.0
 pluggy==1.0.0
 plux==1.3.1
@@ -105,7 +105,7 @@ ptyprocess==0.7.0
 pure-eval==0.2.2
 py-stringmatching==0.4.2
 pyaes==1.6.1
-pyasn1==0.4.8
+pyasn1==0.6.3
 PyAudio==0.2.14
 pybind11==2.11.1
 pycodestyle==2.10.0
@@ -113,7 +113,7 @@ pycparser==2.21
 pydantic==1.10.13
 pydocstyle==6.2.3
 pyflakes==3.0.1
-Pygments==2.15.0
+Pygments==2.20.0
 pyinstaller==6.4.0
 pyinstaller-hooks-contrib==2024.1
 pylint==2.17.1
@@ -129,7 +129,7 @@ pytz==2022.7
 PyWavelets==1.4.1
 PyYAML==6.0
 regex==2023.10.3
-requests==2.32.4
+requests==2.33.0
 rich==13.3.1
 rope==1.7.0
 rsa==4.9
@@ -161,7 +161,7 @@ tokenizers==0.15.0
 toml==0.10.2
 tomli==2.0.1
 tomlkit==0.11.6
-torch==2.8.0
+torch==2.9.1
 tqdm==4.66.3
 traitlets==5.9.0
 transformers==4.53.0
@@ -169,12 +169,12 @@ peft==0.7.1
 translate==3.6.1
 typeguard==2.13.3
 typing_extensions==4.8.0
-ujson==5.7.0
-urllib3==2.6.3
+ujson==5.12.1
+urllib3==2.7.0
 uvicorn==0.23.2
 visions==0.7.5
 wcwidth==0.2.6
-Werkzeug==3.1.5
+Werkzeug==3.1.6
 whatthepatch==1.0.4
 wrapt==1.15.0
 yapf==0.32.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -67,14 +67,14 @@ parsedatetime==2.6
 pexpect==4.8.0
 ptyprocess==0.7.0
 pyasn1==0.6.3
-pyasn1-modules==0.2.1
+pyasn1-modules==0.4.2
 pybind11==2.11.1
 pydantic==2.6.4
 pydantic_core==2.16.3
 PyGObject==3.42.1
 PyHamcrest==2.0.2
 PyICU==2.8.1
-PyJWT==2.12.0
+PyJWT==2.13.0
 pyOpenSSL==21.0.0
 pyparsing==2.4.7
 pyRFC3339==1.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -30,7 +30,7 @@ h11==0.16.0
 httplib2==0.20.2
 huggingface-hub==0.21.4
 hyperlink==21.0.0
-idna==3.7
+idna==3.15
 importlib-metadata==4.6.4
 incremental==21.3.0
 jeepney==0.7.1
@@ -66,7 +66,7 @@ packaging==24.0
 parsedatetime==2.6
 pexpect==4.8.0
 ptyprocess==0.7.0
-pyasn1==0.4.8
+pyasn1==0.6.3
 pyasn1-modules==0.2.1
 pybind11==2.11.1
 pydantic==2.6.4
@@ -74,7 +74,7 @@ pydantic_core==2.16.3
 PyGObject==3.42.1
 PyHamcrest==2.0.2
 PyICU==2.8.1
-PyJWT==2.4.0
+PyJWT==2.12.0
 pyOpenSSL==21.0.0
 pyparsing==2.4.7
 pyRFC3339==1.1
@@ -86,7 +86,7 @@ python-magic==0.4.24
 pytz==2022.1
 PyYAML==5.4.1
 regex==2023.12.25
-requests==2.32.3
+requests==2.33.0
 requests-toolbelt==0.9.1
 safetensors==0.4.2
 SecretStorage==3.3.1
@@ -109,7 +109,7 @@ ubuntu-drivers-common==0.0.0
 ubuntu-pro-client==8001
 ufw==0.36.1
 unattended-upgrades==0.1
-urllib3==2.6.3
+urllib3==2.7.0
 uvicorn==0.29.0
 wadllib==1.3.6
 xkit==0.0.0


### PR DESCRIPTION
## Dependency security bumps (safe patches + minors)

Clears the **non-breaking** Dependabot security alerts on the live requirements files. Scope deliberately limited to within-major patches and minor upgrades — no breaking majors or pre-releases (those are listed below for separate review).

### Bumped (25 across 5 manifests)
| Package | New version | Notes |
|---|---|---|
| urllib3 | 2.7.0 | high |
| idna | 3.15 | medium |
| pyasn1 | 0.6.3 | high |
| PyJWT | 2.12.0 | high |
| requests | 2.33.0 | medium |
| aiohttp | 3.14.0 | high/medium |
| cryptography | 46.0.7 | high |
| ecdsa | 0.19.2 | medium |
| Pillow | 12.2.0 | high |
| Pygments | 2.20.0 | low |
| ujson | 5.12.1 | high |
| Werkzeug | 3.1.6 | medium |
| torch | 2.9.1 (`<2.10`) | medium; within 2.x |

Files: `requirements.txt`, `src/requirements.txt`, `requirements-security.txt` (production/Docker), `requirements-minimal.txt`, `src/mBERT/training/model-training/requirements.txt`. All pinned versions verified to exist on PyPI.

### Held for separate review (NOT in this PR)
Breaking majors / pre-releases / no published fix:
- **starlette 1.0.1** — major; conflicts with the pinned FastAPI.
- **transformers 5.0.0rc3**, **Twisted 26.4.0rc2** — pre-release.
- **pyOpenSSL 26**, **lxml 6.1** (high), **python-dotenv 1.x**, **Flask-Cors 6** — major upgrades needing a compatibility pass.
- **torch in `src/requirements.txt`** — kept at 2.7.1 because that file is a frozen env with matched `triton`/`nvidia-*cu12` pins; bumping torch there would desync the CUDA stack.
- **ecdsa (high)** and **scapy** — no fixed version published upstream.

### Legacy alerts (no action needed)
~165 of the 243 alerts are in `src/BERT/training/bert-mlx-apple-silicon/` and `src/mBERT/training/mbert-mlx-apple-silicon/` — directories that were **deleted** in the "remove legacy architectures" cleanup and no longer exist on the active branches. They persist only because the default branch predates that cleanup, and will auto-resolve when it merges.
