### PR TITLE
ci: make automated PR review manual-only

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,14 +1,12 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  # Manual-only trigger. The automated review previously ran on every PR push
+  # (pull_request: opened, synchronize), which flooded PR threads with repeated
+  # bot review comments and drowned out human conversation. Run it on demand
+  # instead — from the Actions tab ("Run workflow") or the gh CLI:
+  #   gh workflow run "Claude Code Review" --ref <branch>
+  workflow_dispatch:
 
 jobs:
   claude-review:


### PR DESCRIPTION
## What

Changes `.github/workflows/claude-code-review.yml` to trigger on `workflow_dispatch` (manual) instead of `pull_request: [opened, synchronize]`.

## Why

The automated review ran on **every push to every PR**, posting a fresh review comment each time. On PR #202 this produced 18 stacked bot comments (including duplicate full reviews and a couple of stray "test" comments) that buried the human discussion. Making it manual-only stops the per-push flooding while keeping the capability available on demand.

## Effect

- No automated review on PR open/push anymore.
- Run it deliberately when wanted, from the **Actions** tab (Run workflow) or:
  ```
  gh workflow run "Claude Code Review" --ref <branch>
  ```
- The on-demand `@claude` assistant (`claude.yml`) is **unchanged** — it only runs when explicitly mentioned.

No application code touched; this is CI configuration only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qs235KC6Tw9cHi1KrzcLkE)_